### PR TITLE
Revert "No getinitialdata return null"

### DIFF
--- a/integration/src/server.js
+++ b/integration/src/server.js
@@ -38,12 +38,7 @@ server
       const App = sheet.collectStyles(
         <HelmetProvider context={helmetContext}>
           <ApolloProvider client={client}>
-            <ServerUni
-              data={data}
-              routes={routes}
-              location={url}
-              context={{}}
-            />
+            <ServerUni data={data} routes={routes} location={url} />
           </ApolloProvider>
         </HelmetProvider>,
       );

--- a/src/__snapshots__/loadInitialData.test.js.snap
+++ b/src/__snapshots__/loadInitialData.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loadInitialData no matched route should throw an error 1`] = `[Error: No route was found for url.]`;
+exports[`loadInitialData no matched route should return an empty object 1`] = `[Error: No route was found for url.]`;

--- a/src/loadInitialData.js
+++ b/src/loadInitialData.js
@@ -10,7 +10,7 @@ const loadInitialData = async (url, routes) => {
   const { route, match } = matchedRoutes[0];
 
   if (!route.getInitialData) {
-    return null;
+    return {};
   }
 
   try {

--- a/src/loadInitialData.test.js
+++ b/src/loadInitialData.test.js
@@ -6,7 +6,7 @@ describe('loadInitialData', () => {
   const match = { match: true };
 
   describe('no matched route', () => {
-    it('should throw an error', async () => {
+    it('should return an empty object', async () => {
       reactRouterConfig.matchRoutes = jest.fn().mockReturnValue([]);
 
       try {
@@ -18,7 +18,7 @@ describe('loadInitialData', () => {
   });
 
   describe('no getInitialData function on route', () => {
-    it('should return null', async () => {
+    it('should return an empty object', async () => {
       reactRouterConfig.matchRoutes = jest
         .fn()
         .mockReturnValue([
@@ -27,7 +27,7 @@ describe('loadInitialData', () => {
 
       const initialData = await loadInitialData('url', ['url']);
 
-      expect(initialData).toEqual(null);
+      expect(initialData).toEqual({});
     });
   });
 


### PR DESCRIPTION
Reverts jtart/uni#55

Not worth the effort - adds complexity in routing between client routes if a route does not implement `getInitialData`