### PR TITLE
Improve the error for unmatched routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-universal-app",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-universal-app",
   "author": "Jordan Tart <jordan.tart3@gmail.com> (https://github.com/jtart)",
   "description": "Tiny library offering Universal React using React Router.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "homepage": "https://github.com/jtart/react-universal-app",
   "bugs": {

--- a/src/loadInitialData.js
+++ b/src/loadInitialData.js
@@ -2,6 +2,7 @@ import { matchRoutes } from 'react-router-config';
 
 const loadInitialData = async (url, routes) => {
   const matchedRoutes = matchRoutes(routes, url);
+
   if (matchedRoutes.length <= 0) {
     throw new Error(
       `No route was found for '${url}' given the regex '${routes[0]['path']}'`,

--- a/src/loadInitialData.js
+++ b/src/loadInitialData.js
@@ -5,7 +5,8 @@ const loadInitialData = async (url, routes) => {
 
   if (matchedRoutes.length <= 0) {
     throw new Error(
-      `No route was found for '${url}' given the regex '${routes[0]['path']}'`,
+      `No route was found for '${url}' given the regex 
+      '/${routes[0]['path']}/'`,
     );
   }
 

--- a/src/loadInitialData.js
+++ b/src/loadInitialData.js
@@ -2,9 +2,10 @@ import { matchRoutes } from 'react-router-config';
 
 const loadInitialData = async (url, routes) => {
   const matchedRoutes = matchRoutes(routes, url);
-
   if (matchedRoutes.length <= 0) {
-    throw new Error(`No route was found for ${url}.`);
+    throw new Error(
+      `No route was found for '${url}' given the regex '${routes[0]['path']}'`,
+    );
   }
 
   const { route, match } = matchedRoutes[0];


### PR DESCRIPTION
Improves the error so that the regex is also output with the failing route.

![image](https://user-images.githubusercontent.com/7791726/50689481-cebd7a00-1021-11e9-87df-255a001edfa7.png)
